### PR TITLE
Consistency with datetime default value

### DIFF
--- a/moceanapi/config.php
+++ b/moceanapi/config.php
@@ -44,7 +44,7 @@ function checkLogSource() {
      message text,
      receivers text,
      response text,
-     logged_at DATETIME DEFAULT 0);";
+     logged_at DATETIME DEFAULT NULL);";
 
     $stmt = $db->prepare($sql);
     $stmt->execute();


### PR DESCRIPTION
We use null instead of 0